### PR TITLE
Fix json_response parameter name

### DIFF
--- a/src/wisp.gleam
+++ b/src/wisp.gleam
@@ -198,8 +198,8 @@ pub fn html_response(html: StringBuilder, status: Int) -> Response {
 /// // -> Response(200, [#("content-type", "application/json")], Text(body))
 /// ```
 /// 
-pub fn json_response(html: StringBuilder, status: Int) -> Response {
-  HttpResponse(status, [#("content-type", "application/json")], Text(html))
+pub fn json_response(json: StringBuilder, status: Int) -> Response {
+  HttpResponse(status, [#("content-type", "application/json")], Text(json))
 }
 
 /// Set the body of a response to a given HTML document, and set the


### PR DESCRIPTION
Hello 🙂 

I've noticed that the parameter had the wrong name since the function is dealing with JSON and not HTML.

I haven't found any other occurrences for `json_response` that would require an update, just this one file, and the test suite passes.