### PR TITLE
fix: remove warnings about transitive dependencies imports

### DIFF
--- a/examples/0-hello-world/gleam.toml
+++ b/examples/0-hello-world/gleam.toml
@@ -5,6 +5,8 @@ description = "A Wisp example"
 [dependencies]
 gleam_stdlib = "~> 0.30"
 wisp = { path = "../.." }
+gleam_erlang = "~> 0.22"
+mist = "~> 0.13"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"


### PR DESCRIPTION
If it's OK for you, I can create pull requests for other examples as I read them :)