### PR TITLE
Update wisp.gleam, fix double-import

### DIFF
--- a/src/wisp.gleam
+++ b/src/wisp.gleam
@@ -8,9 +8,7 @@ import gleam/erlang
 import gleam/http.{type Method}
 import gleam/http/cookie
 import gleam/http/request.{type Request as HttpRequest}
-import gleam/http/response.{
-  type Response as HttpResponse, Response as HttpResponse,
-}
+import gleam/http/response.{type Response as HttpResponse}
 import gleam/int
 import gleam/json
 import gleam/list


### PR DESCRIPTION
Fixes a bug that was introduced by 23d14773, maybe a bug in `wisp fix`?

`Response` is being doubly imported and aliased.

```
$ gleam --version
gleam 0.32.1

$ gleam build
  Compiling wisp
error: Duplicate type definition
   ┌─ ../dev/wisp/src/wisp.gleam:12:3
   │
12 │   type Response as HttpResponse, Response as HttpResponse,
   │   ^^^^^^^^^^^^^                  ^^^^^^^^ Redefined here
   │   │
   │   First defined here

The type `HttpResponse` has been defined multiple times.
Names in a Gleam module must be unique so one will need to be renamed.
```
